### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+############################################################
+# Repository Owner: @riskalyze/solo
+############################################################
+
+* @riskalyze/solo
+infra/ @riskalyze/solo
+.github/ @riskalyze/solo
+.github/CODEOWNERS @riskalyze/codeowners

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,9 @@
+_extends: probot-settings
+
+repository:
+  name: sops-operator
+  description: A Kubernetes operator for [Mozilla SOPS](https://github.com/mozilla/sops).
+
+teams:
+  - name: solo
+    permission: push


### PR DESCRIPTION
Add a CODEOWNERS file to the repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add CODEOWNERS and GitHub repository settings, including repo metadata and team permissions.
> 
> - **GitHub config**:
>   - **`/.github/CODEOWNERS`**: Define ownership for `*`, `infra/`, `.github/`, and `.github/CODEOWNERS` (owned by `@riskalyze/solo` and `@riskalyze/codeowners`).
>   - **`/.github/settings.yml`**: Configure repository name/description and grant `push` permission to the `solo` team.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 602c9836368f769023276e5108eddafe0b4f8f78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->